### PR TITLE
Add output files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Output files
+ccqueue
+delay
+faa
+lcrq
+msqueue
+wfqueue
+wfqueue0
+
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
These files are generated by `make` and shouldn't be checked in, so I added them to the `.gitignore`.
