### PR TITLE
Fixes needed to repro heap-use-after-free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 TESTS = wfqueue wfqueue0 lcrq ccqueue msqueue faa delay
 
-CC = gcc
-CFLAGS = -g -Wall -O3 -pthread -D_GNU_SOURCE
-LDLIBS = -lpthread -lm
+CC = gcc-5
+CFLAGS = -g -Wall -O3 -fsanitize=address -pthread -D_GNU_SOURCE
+LDLIBS = -lpthread -lm -lasan
 
 ifeq (${VERIFY}, 1)
 	CFLAGS += -DVERIFY

--- a/wfqueue.h
+++ b/wfqueue.h
@@ -7,7 +7,8 @@
 #define EMPTY ((void *) 0)
 
 #ifndef WFQUEUE_NODE_SIZE
-#define WFQUEUE_NODE_SIZE ((1 << 10) - 2)
+//#define WFQUEUE_NODE_SIZE ((1 << 10) - 2)
+#define WFQUEUE_NODE_SIZE 4
 #endif
 
 struct _enq_t {


### PR DESCRIPTION
vagrant@vagrant-ubuntu-trusty-64:/vagrant/fast-wait-free-queue$ ./wfqueue
===========================================
  Benchmark: ./wfqueue
  Number of processors: 4
  Number of operations: 10000000
=================================================================
==18954==ERROR: AddressSanitizer: heap-use-after-free on address 0x62503173e040 at pc 0x0000004030f9 bp 0x7f22463fda80 s
p 0x7f22463fda78
READ of size 8 at 0x62503173e040 thread T2
    #0 0x4030f8 in cleanup /vagrant/fast-wait-free-queue/wfqueue.c:75
    #1 0x4030f8 in dequeue /vagrant/fast-wait-free-queue/wfqueue.c:347
    #2 0x40434a in benchmark /vagrant/fast-wait-free-queue/pairwise.c:52
    #3 0x403b0b in thread /vagrant/fast-wait-free-queue/harness.c:129
    #4 0x7f2249e1b183 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8183)
    #5 0x7f224984237c in clone (/lib/x86_64-linux-gnu/libc.so.6+0xfa37c)

0x62503173e040 is located 64 bytes inside of 384-byte region [0x62503173e000,0x62503173e180)
freed by thread T2 here:
    #0 0x7f224a0c51aa in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x941aa)
    #1 0x4032e7 in cleanup /vagrant/fast-wait-free-queue/wfqueue.c:99
    #2 0x4032e7 in dequeue /vagrant/fast-wait-free-queue/wfqueue.c:347
    #3 0x40434a in benchmark /vagrant/fast-wait-free-queue/pairwise.c:52

previously allocated by thread T0 here:
    #0 0x7f224a0c5d8e in __interceptor_posix_memalign (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x94d8e)
    #1 0x402d01 in align_malloc /vagrant/fast-wait-free-queue/align.h:17
    #2 0x402d01 in new_node /vagrant/fast-wait-free-queue/wfqueue.c:39
    #3 0x402d01 in dequeue /vagrant/fast-wait-free-queue/wfqueue.c:348
    #4 0x40434a in benchmark /vagrant/fast-wait-free-queue/pairwise.c:52

Thread T2 created by T0 here:
    #0 0x7f224a067474 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36474)
    #1 0x401230 in main /vagrant/fast-wait-free-queue/harness.c:182
    #2 0x7f2249769f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

SUMMARY: AddressSanitizer: heap-use-after-free /vagrant/fast-wait-free-queue/wfqueue.c:75 cleanup
Shadow bytes around the buggy address:
  0x0c4a862dfbb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfbc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfbd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfbe0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfbf0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c4a862dfc00: fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x0c4a862dfc10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a862dfc20: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4a862dfc30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfc40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4a862dfc50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
==18954==ABORTING