### PR TITLE
Thread->Ep should not cross Q->Ei

### DIFF
--- a/wfqueue.c
+++ b/wfqueue.c
@@ -78,7 +78,11 @@ static void cleanup(queue_t *q, handle_t *th) {
     if (oid == -1) return;
     if (new->id - oid < MAX_GARBAGE(q->nprocs)) return;
     if (!CASa(&q->Hi, &oid, -1)) return;
-
+    
+    long Di = q->Di, Ei = q->Ei;
+    while(Ei <= Di && !CAS(&q->Ei, &Ei, Di + 1))
+        ;
+    
     node_t *old = q->Hp;
     handle_t *ph = th;
     handle_t *phs[q->nprocs];
@@ -228,10 +232,12 @@ static void *help_enq(queue_t *q, handle_t *th, cell_t *c, long i) {
             ph = th->Eh, pe = &ph->Er, id = pe->id;
         }
 
-        if (id > 0 && id <= i && !CAS(&c->enq, &e, pe))
+        if (id > 0 && id <= i && !CAS(&c->enq, &e, pe) && e != pe)
             th->Ei = id;
-        else
+        else {
+            th->Ei = 0;
             th->Eh = ph->next;
+        }
 
         if (e == BOT && CAS(&c->enq, &e, TOP)) e = TOP;
     }


### PR DESCRIPTION
- Becaulse this memory reclaimation may update one's Ep with one's Dp, So maybe one thread's Ep have skip over q->Ei, this caused enq-thread can't targeting the right cell, It targeting at the next Node's Cell at he same index wrongly at least. 
for example, two threads, one for enqueue, one for dequeue, deq-thread working crazily and get null, but have increase Dp, and cleanup soonly. Enq-thread do nothing until its Ep has update, then q->Ei and Ep is not match for the enqueue working. Ep has skip over q->Ei.
This is a strange behavior and I think it should be fixed.

- Provide a little better help :)