### PR TITLE
Keep one cell responsible for one enqueue request at most(v2)

### DIFF
--- a/wfqueue.c
+++ b/wfqueue.c
@@ -84,12 +84,13 @@ static node_t *update(node_t *volatile *pPn, node_t *cur,
 
 static void cleanup(queue_t *q, handle_t *th) {
     long oid = ACQUIRE(&q->Hi);
-    node_t *new = th->Dp;
+    long id = th->deq_node_id;
 
     if (oid == -1) return;
-    if (new->id - oid < MAX_GARBAGE(q->nprocs)) return;
+    if (id - oid < MAX_GARBAGE(q->nprocs)) return;
     if (!CASa(&q->Hi, &oid, -1)) return;
     
+    node_t *new = th->Dp;
     long Di = q->Di, Ei = q->Ei;
     while(Ei <= Di && !CAS(&q->Ei, &Ei, Di + 1))
         ;

--- a/wfqueue.c
+++ b/wfqueue.c
@@ -191,6 +191,7 @@ static void enq_slow(queue_t *q, handle_t *th, void *v, long id) {
             ;
     }
     c->val = v;
+    c->used = 1;
 
 #ifdef RECORD
     th->slowenq++;
@@ -250,7 +251,7 @@ static void *help_enq(queue_t *q, handle_t *th, cell_t *c, long i) {
     if (ei > i) {
         if (c->val == TOP && q->Ei <= i) return BOT;
     } else {
-        if ((ei > 0 && CAS(&e->id, &ei, -i)) || (ei == -i && c->val == TOP)) {
+        if ((ei > 0 && !c->used && CAS(&e->id, &ei, -i)) || (ei == -i && c->val == TOP)) {
             long Ei = q->Ei;
             while (Ei <= i && !CAS(&q->Ei, &Ei, i + 1))
                 ;

--- a/wfqueue.c
+++ b/wfqueue.c
@@ -28,8 +28,8 @@ static inline void *spin(void *volatile *p) {
     void *v = *p;
 
     while (!v && patience-- > 0) {
-        v = *p;
         PAUSE();
+        v = *p;
     }
 
     return v;
@@ -39,8 +39,8 @@ static inline void *spin_util_val(struct _enq_t * volatile* p) {
     void *v = *p;
 
     while (!v) {
-        v = *p;
         PAUSE();
+        v = *p;
     }
 
     return v;

--- a/wfqueue.c
+++ b/wfqueue.c
@@ -191,7 +191,7 @@ static void enq_slow(queue_t *q, handle_t *th, void *v, long id) {
         if (CAScs(&c->help_enq_id, &chei, id) || chei == id) {
             c->enq = enq;
             if (c->val != TOP) {
-                CAS(&enq->id, &id, -i);
+                if (CAS(&enq->id, &id, -i)) id = -i;
                 break;
             }
         }

--- a/wfqueue.h
+++ b/wfqueue.h
@@ -24,7 +24,8 @@ struct _cell_t {
   void * volatile val;
   struct _enq_t * volatile enq;
   struct _deq_t * volatile deq;
-  void * pad[5];
+  long used;
+  void * pad[4];
 };
 
 struct _node_t {

--- a/wfqueue.h
+++ b/wfqueue.h
@@ -24,7 +24,7 @@ struct _cell_t {
   void * volatile val;
   struct _enq_t * volatile enq;
   struct _deq_t * volatile deq;
-  long used;
+  long help_enq_id;
   void * pad[4];
 };
 


### PR DESCRIPTION
Hi, 
I add a help_enq_id(long) to Cell, It takes the place of enq, as we first tranform cell->help_enq_id to the unique enqueue request's id through CAS, and then put the associative enq into the cell. It address the question of #14, so we can compare cell's  help_enq_id with enq's id to distinguish differing cases.
Now we can ensure when multiple help_enq are invoked on the same cell, they will produce one and only one unique enqueue result state for that cell.

The bad side is that this implementation is not wait-free. Actually It's blocking, When we do not hold the enq corresponding to the cell, we can only wait for the giving of another thread. But it's still high-performance.