### PR TITLE
Avoid double-free by only freeing each queue once

### DIFF
--- a/halfhalf.c
+++ b/halfhalf.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include "delay.h"
 #include "queue.h"
+#include "primitives.h"
 
 #ifndef LOGN_OPS
 #define LOGN_OPS 7
@@ -37,7 +38,10 @@ void thread_init(int id, int nprocs) {
 }
 
 void thread_exit(int id, int nprocs) {
-  queue_free(q, hds[id]);
+  // Only free the queue from a single thread, to avoid double-free
+  static int lock = 0;
+  if (FAA(&lock, 1) == 0)
+    queue_free(q, hds[id]);
 }
 
 void * benchmark(int id, int nprocs) {

--- a/pairwise.c
+++ b/pairwise.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include "delay.h"
 #include "queue.h"
+#include "primitives.h"
 
 #ifndef LOGN_OPS
 #define LOGN_OPS 7
@@ -57,7 +58,10 @@ void * benchmark(int id, int nprocs) {
 }
 
 void thread_exit(int id, int nprocs) {
-  queue_free(q, hds[id]);
+  // Only free the queue from a single thread, to avoid double-free
+  static int lock = 0;
+  if (FAA(&lock, 1) == 0)
+    queue_free(q, hds[id]);
 }
 
 #ifdef VERIFY


### PR DESCRIPTION
This was mainly an issue with LCRQ, which actually implements a free function. However, this function was called from every thread when they exited, leading to a segmentation fault in most runs. Now it only lets a single thread free the queue in the benchmarks.